### PR TITLE
MAINT: add env file for QIIME 2 2025.10

### DIFF
--- a/environment-files/q2-ena-uploader-qiime2-tiny-2025.10.yml
+++ b/environment-files/q2-ena-uploader-qiime2-tiny-2025.10.yml
@@ -1,0 +1,11 @@
+channels:
+- https://packages.qiime2.org/qiime2/2025.10/tiny/released
+- conda-forge
+- bioconda
+dependencies:
+  - qiime2-tiny
+  - pandas
+  - pip
+  - pip:
+    - q2-ena-uploader@git+https://github.com/bokulich-lab/q2-ena-uploader.git@main
+    


### PR DESCRIPTION
This PR adds a new environment file for QIIME 2 2025.10.

Generated from the latest env file in 'environment-files/' by updating the release token.