### PR TITLE
MAINT: add env file for QIIME 2 2026.1

### DIFF
--- a/environment-files/q2-ena-uploader-qiime2-tiny-2026.1.yml
+++ b/environment-files/q2-ena-uploader-qiime2-tiny-2026.1.yml
@@ -1,0 +1,11 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.1/tiny/released
+- conda-forge
+- bioconda
+dependencies:
+  - qiime2-tiny
+  - pandas
+  - pip
+  - pip:
+    - q2-ena-uploader@git+https://github.com/bokulich-lab/q2-ena-uploader.git@2026.1.0
+    


### PR DESCRIPTION
This PR adds a new environment file for QIIME 2 2026.1.

Generated from the latest env file in 'environment-files/' by updating the release token.